### PR TITLE
Add a 10 seconds delay option to the Sticky button

### DIFF
--- a/UWPSpy/MainDlg.cpp
+++ b/UWPSpy/MainDlg.cpp
@@ -1517,6 +1517,13 @@ void CMainDlg::OnTimer(UINT_PTR nIDEvent) {
             break;
         }
 
+        case TIMER_ID_STICKY_DELAYED:
+            KillTimer(nIDEvent);
+
+            m_sticky = true;
+            CButton(GetDlgItem(IDC_STICKY)).SetCheck(BST_CHECKED);
+            break;
+
         case TIMER_ID_SET_SELECTED_ELEMENT_INFORMATION:
             KillTimer(nIDEvent);
             SetSelectedElementInformation();
@@ -1592,6 +1599,12 @@ void CMainDlg::OnContextMenu(CWindow wnd, CPoint point) {
     auto visualStatesTree = CTreeViewCtrlEx(GetDlgItem(IDC_VISUAL_STATE_TREE));
     if (wnd == visualStatesTree) {
         OnVisualStateContextMenu(visualStatesTree, point);
+        return;
+    }
+
+    auto stickyButton = CButton(GetDlgItem(IDC_STICKY));
+    if (wnd == stickyButton) {
+        OnStickyContextMenu(stickyButton, point);
         return;
     }
 }
@@ -2153,6 +2166,36 @@ void CMainDlg::OnHighlightSelection(UINT uNotifyCode, int nID, CWindow wndCtl) {
 
 void CMainDlg::OnSticky(UINT uNotifyCode, int nID, CWindow wndCtl) {
     m_sticky = CButton(wndCtl).GetCheck() != BST_UNCHECKED;
+
+    // Cancel a pending delayed sticky if the checkbox was toggled manually.
+    KillTimer(TIMER_ID_STICKY_DELAYED);
+}
+
+void CMainDlg::OnStickyContextMenu(CButton stickyButton, CPoint point) {
+    CPoint menuPoint = point;
+    if (menuPoint.x == -1 && menuPoint.y == -1) {
+        // The context menu was invoked via the keyboard, use the center of
+        // the button.
+        CRect rect;
+        stickyButton.GetWindowRect(&rect);
+        menuPoint = rect.CenterPoint();
+    }
+
+    CMenu menu;
+    menu.CreatePopupMenu();
+
+    enum { MENU_ID_STICKY_DELAYED = 1 };
+
+    menu.AppendMenu(MF_STRING | (m_sticky ? MF_GRAYED : 0),
+                    MENU_ID_STICKY_DELAYED, L"Sticky (10 seconds delay)");
+
+    int nCmd = menu.TrackPopupMenu(TPM_RIGHTBUTTON | TPM_RETURNCMD, menuPoint.x,
+                                   menuPoint.y, m_hWnd);
+    switch (nCmd) {
+        case MENU_ID_STICKY_DELAYED:
+            SetTimer(TIMER_ID_STICKY_DELAYED, 10000);
+            break;
+    }
 }
 
 void CMainDlg::OnAppAbout(UINT uNotifyCode, int nID, CWindow wndCtl) {

--- a/UWPSpy/MainDlg.h
+++ b/UWPSpy/MainDlg.h
@@ -14,6 +14,7 @@ class CMainDlg : public CDialogImpl<CMainDlg>, public CDialogResize<CMainDlg> {
         TIMER_ID_SET_SELECTED_ELEMENT_INFORMATION,
         TIMER_ID_REFRESH_SELECTED_ELEMENT_INFORMATION,
         TIMER_ID_COPY_SUBTREE_DELAYED,
+        TIMER_ID_STICKY_DELAYED,
     };
 
     enum {
@@ -190,6 +191,7 @@ class CMainDlg : public CDialogImpl<CMainDlg>, public CDialogResize<CMainDlg> {
     void OnElementTreeContextMenu(CTreeViewCtrlEx treeView, CPoint point);
     void OnAttributesListContextMenu(CListViewCtrl listView, CPoint point);
     void OnVisualStateContextMenu(CTreeViewCtrlEx treeView, CPoint point);
+    void OnStickyContextMenu(CButton stickyButton, CPoint point);
     void DumpElementRecursive(std::wstring& output,
                               InstanceHandle handle,
                               bool isFirst);


### PR DESCRIPTION
Right-clicking the Sticky checkbox now shows a context menu with a "Sticky (10 seconds delay)" option, which enables sticky mode after a 10 second countdown.

This follows the existing pattern of the delayed "Copy subtree" commands and gives time to prepare the target UI (e.g., open a flyout or menu in the inspected app) before the window can no longer be deactivated.

Implementation details:
- New `TIMER_ID_STICKY_DELAYED` timer; when it fires, the Sticky checkbox is checked and sticky mode is enabled.
- The context menu is shown via the existing `WM_CONTEXTMENU` handler in `OnContextMenu`, alongside the tree/list handlers. When invoked via keyboard, the menu is positioned at the center of the button.
- Toggling the checkbox manually cancels a pending delayed sticky.
- The menu item is grayed out while sticky mode is already active.